### PR TITLE
fix: redirect to site if plug not installed

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -58,6 +58,12 @@ const PlugConnect = ({
   onConnectCallback: (...args : any[]) => any,
 }) => {
   const handleConnect = async () => {
+    
+    if(!window.ic?.plug){
+      window.open('https://plugwallet.ooo/','_blank');
+      return;
+    }
+    
     // @ts-ignore
     const connected = await window?.ic?.plug?.requestConnect({
       whitelist,


### PR DESCRIPTION
## Why?

Should redirect the user to dowload plug if its not installed