### PR TITLE
fix: Casted windows because typescript

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -59,13 +59,13 @@ const PlugConnect = ({
 }) => {
   const handleConnect = async () => {
     
-    if(!window.ic?.plug){
+    if(!(window as any).ic?.plug){
       window.open('https://plugwallet.ooo/','_blank');
       return;
     }
     
     // @ts-ignore
-    const connected = await window?.ic?.plug?.requestConnect({
+    const connected = await (window as any)?.ic?.plug?.requestConnect({
       whitelist,
       host,
     });


### PR DESCRIPTION
## Why?
Build was crashing because TS does not recognize IC as a part of the window object

## How?
- Casted as any

